### PR TITLE
Made CampGallery mobile carousel cards fluid

### DIFF
--- a/src/blocks/camp/CampGallery/Component.tsx
+++ b/src/blocks/camp/CampGallery/Component.tsx
@@ -197,7 +197,14 @@ export const CampGalleryBlock: React.FC<CampGalleryBlockProps> = ({ title, link,
                 <div
                   key={i}
                   className={`relative flex-none overflow-hidden bg-muted rounded-lg${!isTall ? ' mt-10' : ''}`}
-                  style={{ width: '280px', height: isTall ? '260px' : '200px' }}
+                  // `min(280px, 80vw)` keeps the original look on standard phones (375px+)
+                  // while shrinking on foldables / very small viewports so the next card
+                  // still peeks in. Aspect ratio preserves the original 280×260 / 280×200
+                  // proportions regardless of the resolved width.
+                  style={{
+                    width: 'min(280px, 80vw)',
+                    aspectRatio: isTall ? '14 / 13' : '7 / 5',
+                  }}
                 >
                   {item?.image && typeof item.image === 'object' && (
                     <Media resource={item.image} fill imgClassName="object-cover" />


### PR DESCRIPTION
The mobile auto-scrolling carousel used fixed pixel sizes: `width: 280px; height: 260px | 200px`. On viewports narrower than ~340px (foldables, the smallest Androids) a card filled the entire screen with no visible peek of the next image, breaking the visual cue that the row scrolls. There was no horizontal overflow bug since the parent is `overflow-hidden` and the animation translates the whole track, but the carousel didn't read as a carousel.

Switched to `width: min(280px, 80vw)` plus `aspectRatio`:
- On phones 350px+, `80vw` exceeds 280px, the cap kicks in and the look is byte-identical to before (280×260 / 280×200).
- On smaller viewports, the width tracks 80vw so ~20% of the next card peeks in. `aspectRatio: 14 / 13` and `7 / 5` preserve the original card proportions regardless of the resolved width — short cards stay shorter, tall cards stay taller, and the `mt-10` offset on short cards keeps the staggered "alpine pinboard" look.

The rest of the codebase's fixed-pixel widths were checked and intentionally left alone: `max-w-[380px]` on the CampHero flyer and `max-w-[260px]` on CampSponsors are upper bounds combined with `w-full`, so they're already fluid. The Logo's `h-[34px]` is a fixed height for layout stability while widths scale (`max-w-[9rem]` → `sm:max-w-[14rem]`). The desktop mosaic's `maxWidth: 1400px` is likewise a cap, not a fixed width — it sits inside `width: 100%`.